### PR TITLE
Slice 5: Admin panel + CRUD API, type-safe client, safer in-memory DB

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,7 @@
+import AdminClient from "@/components/admin/AdminClient";
+//Admin is personalized/editor-like; avoid static prerender.
+export const dynamic = "force-dynamic";
+
+export default function AdminPage(){
+    return <AdminClient />
+}

--- a/src/app/api/admin/conferences/[id]/route.ts
+++ b/src/app/api/admin/conferences/[id]/route.ts
@@ -65,6 +65,7 @@ function validatePartialForUpdate(partial: Partial<Conference>){
     return issues;
 }
 
+export const dynamic = "force-dynamic";
 export async function GET(
     _request: Request,
     { params }: { params: Promise<{ id: string }> }
@@ -94,6 +95,10 @@ export async function PUT(
     }
 
     const partial = raw as Partial<Conference>;
+    //Defensive approach, never allow id to be updated; drop it
+    if("id" in partial){
+        delete (partial as Record<string, unknown>).id;
+    }
     const issues = validatePartialForUpdate(partial);
     if(issues.length){
         return NextResponse.json({ error: issues.join(" ")}, { status: 400 });

--- a/src/app/api/admin/conferences/[id]/route.ts
+++ b/src/app/api/admin/conferences/[id]/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/server/db";
+import type { Conference, Speaker } from "@/lib/types";
+
+function validatePartialForUpdate(partial: Partial<Conference>){
+    const issues: string[] = [];
+    if(partial.id !== undefined) {
+        issues.push('Field "id" cannot be updated.');
+    }
+    if(partial.price !== undefined && (typeof partial.price !== "number" || partial.price < 0)) {
+        issues.push('Field "price" must be a non-negative number.');
+    }
+    if(partial.maxAttendees !== undefined && (typeof partial.maxAttendees !== "number" || partial.maxAttendees <= 0)) {
+        issues.push('Field "maxAttendees" must be a positive number.');
+    }
+    if(partial.currentAttendees !== undefined &&(typeof partial.currentAttendees !== "number" || partial.currentAttendees < 0)) {
+        issues.push('Field "currentAttendees" must be a non-negative number.');
+    }
+    if(partial.date !== undefined){
+        const startMs = new Date(partial.date).getTime();
+        if(Number.isNaN(startMs)) {
+            issues.push('Field "date" must be a valid ISO date string.');
+        }
+    }
+    if(partial.endDate !== undefined) {
+        const endMs = new Date(partial.endDate).getTime();
+        if(Number.isNaN(endMs)){
+            issues.push('Field "endDate" must be a valid ISO date string.');
+        }
+    }
+    if(partial.date !== undefined && partial.endDate !== undefined) {
+        const startMs = new Date(partial.date).getTime();
+        const endMs = new Date(partial.endDate).getTime();
+        if(!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs < startMs) {
+            issues.push("endDate must be the same as or after date.");
+        }
+    } 
+    //Optional field type checks when provided
+    if(partial.category !== undefined){
+        if(!Array.isArray(partial.category) || !partial.category.every((tag) => typeof tag === "string")){
+            issues.push('Field "category" must be an array of strings.');
+        }
+    }
+    if(partial.imageUrl !== undefined && typeof partial.imageUrl !== "string") {
+        issues.push('Field "imageUrl" must be a string.');
+    }
+    if(partial.isFeatured !== undefined && typeof partial.isFeatured !== "boolean"){
+        issues.push('Field "isFeatured" must be a boolean.');
+    }
+    if(partial.speakers !== undefined) {
+        if(!Array.isArray(partial.speakers) || !partial.speakers.every((speaker) =>
+            speaker &&
+            typeof speaker === "object" &&
+            typeof(speaker as Speaker).id === "string" &&
+            typeof(speaker as Speaker).name === "string" &&
+            typeof(speaker as Speaker).title === "string" &&
+            typeof(speaker as Speaker).company === "string" &&
+            typeof(speaker as Speaker).bio === "string"
+            && ((speaker as Speaker).avatarUrl === undefined || typeof(speaker as Speaker).avatarUrl === "string")
+            )
+        ) {
+            issues.push('Field "speakers" must be an array of speaker objects.');
+        }
+    }  
+    return issues;
+}
+
+export async function GET(
+    _request: Request,
+    { params }: { params: Promise<{ id: string }> }
+){
+    const { id } = await params;
+    const record = db.get(id);
+    if(!record) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(record);
+}
+
+export async function PUT(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const { id } = await params;
+    
+    //Parse JSON first
+    let raw: unknown;
+    try{
+        raw = await request.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON payload."}, { status: 400 });
+    }
+
+    if(typeof raw !== "object" || raw === null) {
+        return NextResponse.json({ error: "Payload must be an object." }, { status: 400 });
+    }
+
+    const partial = raw as Partial<Conference>;
+    const issues = validatePartialForUpdate(partial);
+    if(issues.length){
+        return NextResponse.json({ error: issues.join(" ")}, { status: 400 });
+    }
+
+    //Ensure record exists (clearer 404 than a thrown error inside db.update)
+    const existing = db.get(id);
+    if(!existing) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const allowed: (keyof Conference)[] = [
+        "name", "description", "date", "endDate", "location", "price", "category", "imageUrl", "speakers", "maxAttendees", "currentAttendees", "isFeatured"
+    ];
+    const safePartial = Object.fromEntries(
+        Object.entries(partial).filter(([key]) => allowed.includes(key as keyof Conference))
+    ) as Partial<Conference>;
+    const updated = db.update(id, safePartial);
+    return NextResponse.json(updated);
+}
+
+export async function DELETE(
+    _request: Request,
+    { params }: { params: Promise<{ id: string }> }
+){
+    const { id } = await params;
+    const existing = db.get(id);
+    if(!existing){
+        return NextResponse.json({ error: "Not found"}, { status: 404 });
+    }
+    db.delete(id);
+    return new NextResponse(null, { status: 204 });
+}
+

--- a/src/app/api/admin/conferences/route.ts
+++ b/src/app/api/admin/conferences/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/server/db";
+import type { Conference, Speaker } from "@/lib/types";
+
+/** Shallow validation for required core fields */
+function validatConferenceInput(input: Partial<Conference>){
+    const issues: string[] = [];
+    if(!input.id || !/^[a-z0-9-]+$/i.test(input.id)) {
+        issues.push('Field "id" is required and must be slug-like (letters, numbers, dashes).');
+    }
+    if(!input.name) {
+        issues.push('Field "name" is required.');
+    }
+    if(!input.date){
+        issues.push('Field "date" is required.');
+    } else {
+        const startMs = new Date(input.date).getTime();
+        if(Number.isNaN(startMs)) {
+            issues.push('Field "date" must be a valid ISO date string.');
+        }
+    }
+    if(!input.location) {
+        issues.push('Field "location" is required.');
+    }
+    if(typeof input.price !== "number" || input.price < 0) {
+        issues.push('Field "price" must be a non-negative number.');
+    }
+    if(!Array.isArray(input.category) || !input.category.every(item => typeof item === "string" && item.trim().length > 0)) {
+        issues.push('Field "category" must be a non-empty array of strings.');
+    }
+    if(typeof input.maxAttendees !== "number" || input.maxAttendees <= 0){
+        issues.push('Field "maxAttendees" must be a positive number.');
+    }
+    if(typeof input.currentAttendees !== "number" || input.currentAttendees < 0){
+        issues.push('Field "currentAttendees" must be a non-negative number.');
+    }
+    if(input.endDate) {
+        const startMs = new Date(input.date!).getTime();
+        const endMs = new Date(input.endDate).getTime();
+        if(Number.isNaN(endMs)) {
+            issues.push('Field "endDate" must be a valid ISO date string.');
+        }
+        if(!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs < startMs) {
+            issues.push("endDate must be the same as or after date.");
+        }
+    }
+    if(
+        typeof input.maxAttendees === "number" && typeof input.currentAttendees === "number" && input.currentAttendees > input.maxAttendees
+    ) {
+        issues.push("currentAttendees cannot exceed maxAttendees.");
+    }
+
+    //Shallow speaker validation if provided
+    if(input.speakers !== undefined) {
+        if(!Array.isArray(input.speakers) || !input.speakers.every(s => 
+            s && typeof s === "object" &&
+            typeof(s as Speaker).id === "string" &&
+            typeof(s as Speaker).name === "string" &&
+            typeof(s as Speaker).title === "string" &&
+            typeof(s as Speaker).company === "string" && 
+            typeof(s as Speaker).bio === "string"
+        )){
+            issues.push('Field "speakers" must be an array of speaker objects.');
+        } 
+    }
+    return issues;
+}
+
+export async function GET() {
+    return NextResponse.json({ items: db.list() });
+}
+
+export async function POST(request: Request){
+    try{
+        const raw: unknown = await request.json();
+        if(typeof raw !== "object" || raw === null){
+            return NextResponse.json({ error: "Payload must be an object."}, { status: 400});
+        }
+
+        const payload = raw as Partial<Conference>;
+        const issues = validatConferenceInput(payload);
+        if(issues.length){
+            return NextResponse.json({ error: issues.join(" ")}, { status: 400 });
+        }
+
+        //Fill defaults for optional fields
+        const record: Conference = {
+            id: payload.id!,
+            name: payload.name!,
+            description: payload.description ?? "",
+            date: payload.date!,
+            endDate: payload.endDate,
+            location: payload.location!,
+            price: payload.price ?? 0,
+            category: payload.category ?? [],
+            imageUrl: payload.imageUrl,
+            speakers: payload.speakers  ?? [],
+            maxAttendees: payload.maxAttendees ?? 100,
+            currentAttendees: payload.currentAttendees ?? 0,
+            isFeatured: Boolean(payload.isFeatured),
+        };
+        const created = db.create(record);
+        return NextResponse.json(created, { status: 201 });
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON payload."}, { status: 400 });
+    }
+}

--- a/src/app/api/conferences/route.ts
+++ b/src/app/api/conferences/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { SEED_CONFERENCES } from "@/data/conferences.seed";
+import { db } from "@/lib/server/db";
 
 type ConferenceListQuery = {
     queryText?: string;
@@ -70,7 +70,7 @@ export async function GET(req: Request) {
     const query = parseListQuery(searchParams);
     
     //Filter
-    const filtered = SEED_CONFERENCES.filter((conf) => {
+    const filtered = db.list().filter((conf) => {
         //name search
         if(query.queryText && !conf.name.toLowerCase().includes(query.queryText.toLowerCase())){
             return false;

--- a/src/app/conference/[id]/page.tsx
+++ b/src/app/conference/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { SEED_CONFERENCES } from "@/data/conferences.seed";
+import { db } from "@/lib/server/db";
 import { formatDateRange } from "@/lib/utils/date";
 import { formatPrice } from "@/lib/utils/price";
 import { computeStatus } from "@/lib/utils/status";
@@ -10,7 +10,7 @@ import FavoriteButton from "@/components/common/FavoriteButton";
 export default async function ConferenceDetail({ params }: { params: Promise<{ id: string }>; 
 }){
     const { id } = await params;
-    const conference = SEED_CONFERENCES.find((c) => c.id === id);
+    const conference = db.get(id);
     if(!conference) notFound();
 
     const when = formatDateRange(conference.date, conference.endDate);

--- a/src/app/conference/[id]/page.tsx
+++ b/src/app/conference/[id]/page.tsx
@@ -7,6 +7,8 @@ import Avatar from "@/components/common/Avatar";
 import RegistrationForm from "@/components/conf/RegistrationForm";
 import FavoriteButton from "@/components/common/FavoriteButton";
 
+export const dynamic = "force-dynamic";
+
 export default async function ConferenceDetail({ params }: { params: Promise<{ id: string }>; 
 }){
     const { id } = await params;

--- a/src/components/admin/AdminClient.tsx
+++ b/src/components/admin/AdminClient.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Conference } from "@/lib/types";
+
+type SaveMode = "create" | "edit";
+type EditableConference = Omit<Conference, "speakers">;
+type ApiListResponse = { items: EditableConference[] };
+type ApiError = { error: string };
+
+function emptyConference(): EditableConference {
+    return{
+    id: "",
+    name: "",
+    description: "",
+    date: "",
+    endDate: undefined,
+    location: "",
+    price: 0,
+    category: [],
+    imageUrl: undefined,
+    maxAttendees: 0,
+    currentAttendees: 0,
+    isFeatured: false,
+  };
+}
+
+export default function AdminClient(){
+    const [items, setItems] = useState<EditableConference[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [errorText, setErrorText] = useState<string | null>(null);
+
+    const [mode, setMode] = useState<SaveMode>("create");
+    const [draft, setDraft] = useState<EditableConference>(emptyConference());
+
+    //Fetch List
+    async function refreshList(){
+        setLoading(true);
+        setErrorText(null);
+        try{
+            const res = await fetch("/api/admin/conferences", { cache: "no-store" });
+            // const json = await res.json();
+            // if(queryObjects.ok) throw new Error(json.error || "Failed to load conferences");
+            // setItems(json.items);
+            const data = (await res.json().catch(() => ({}))) as ApiListResponse | ApiError | Record<string, unknown>;
+            if(!res.ok){
+              throw new Error((data as ApiError).error || "Failed to load conferences");
+            }
+            setItems((data as ApiListResponse).items ?? []);
+        } catch (err: unknown){
+            setErrorText(err instanceof Error ? err.message : "Failed to load conferences");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        refreshList();
+    }, []);
+
+  const knownCategories = useMemo(() => 
+    Array.from(new Set(items.flatMap((c) => c.category))).sort(), [items]
+  );
+
+
+    function startCreate() {
+        setMode("create");
+        setDraft(emptyConference());
+    }
+
+    function startEdit(conference: EditableConference) {
+        setMode("edit");
+        setDraft({ ...conference});
+    }
+
+    async function submitDraft(){
+        setErrorText(null);
+        //Client Validation
+        const problems: string[] = [];
+        if(!draft.id) {
+            problems.push("ID is required.");
+        }
+        if(!draft.name){
+            problems.push("Name is required.");
+        }
+        if(!draft.date){
+            problems.push("Start date is required.");
+        }
+        if(!draft.location){
+            problems.push("Location is required.");
+        }
+        if(draft.price < 0){
+            problems.push("Price cannot be negative.");
+        }
+        if(draft.currentAttendees > draft.maxAttendees){
+            problems.push("Current attendees cannot exceed maximum.");
+        }
+        if(draft.endDate){
+            const startMs = new Date(draft.date).getTime();
+            const endMs = new Date(draft.endDate).getTime();
+            if(!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs < startMs) {
+                problems.push("End date must be the same as or after start date.");
+            }
+        }
+        if(problems.length){
+            setErrorText(problems.join(" "));
+            return;
+        }
+
+        const payload: Partial<Conference> = {
+            ...draft,
+            //normalize categories from comma-separated string if user types that in
+            category: Array.isArray(draft.category) 
+                ? draft.category
+                : String(draft.category || "")
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+        };
+
+        if(mode === "create"){
+            const res = await fetch("/api/admin/conferences", {
+                method: "POST",
+                headers: { "Content-Type": "application/json"},
+                body: JSON.stringify(payload),
+            });
+            const data = (await res.json().catch(() => ({}))) as ApiError | Record<string, unknown>;
+            if(!res.ok){
+              setErrorText((data as ApiError).error || "Create failed");
+              return;
+            }
+        } else {
+            const res = await fetch(`/api/admin/conferences/${draft.id}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json"},
+                body: JSON.stringify(payload),
+            });
+            const data = (await res.json().catch(() => ({}))) as ApiError | Record<string, unknown>;
+            if(!res.ok){
+              setErrorText((data as ApiError).error || "Update failed");
+              return;
+            }
+        }
+
+        await refreshList();
+        startCreate();
+    }
+
+    async function deleteConference(id: string) {
+        setErrorText(null);
+        const res = await fetch(`/api/admin/conferences/${id}`, { method: "DELETE" });
+        const json = await res.json().catch(() => ({}));
+        if(!res.ok) {
+            setErrorText(json.error || "Delete failed");
+            return;
+        }
+        await refreshList();
+    }
+
+    return (
+         <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Admin — Conferences</h1>
+        <button className="rounded border px-3 py-2" onClick={refreshList}>
+          Refresh
+        </button>
+      </header>
+
+      {/* Error */}
+      {errorText && (
+        <div className="rounded border border-red-300 bg-red-50 p-3 text-red-800">
+          {errorText}
+        </div>
+      )}
+
+      {/* List */}
+      <section className="rounded border">
+        {loading ? (
+          <div className="p-4 text-neutral-600">Loading…</div>
+        ) : items.length ? (
+          <ul className="divide-y">
+            {items.map((conf) => (
+              <li key={conf.id} className="flex items-center justify-between p-3">
+                <div>
+                  <div className="font-medium">{conf.name}</div>
+                  <div className="text-sm text-neutral-600">
+                    {conf.location} · {conf.category.join(", ")}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    className="rounded border px-2 py-1 text-sm"
+                    onClick={() => startEdit(conf)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="rounded border px-2 py-1 text-sm text-red-700"
+                    onClick={() => deleteConference(conf.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="p-4 text-neutral-600">No conferences yet.</div>
+        )}
+      </section>
+
+      {/* Form */}
+      <section className="rounded border p-4">
+        <h2 className="mb-3 text-lg font-medium">
+          {mode === "create" ? "Create Conference" : `Edit Conference (${draft.id})`}
+        </h2>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {/* ID */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-id">
+              ID (slug)
+            </label>
+            <input
+              id="admin-id"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.id}
+              onChange={(e) => setDraft({ ...draft, id: e.target.value })}
+              disabled={mode === "edit"}
+              placeholder="react-summit-2026"
+              required
+            />
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-name">
+              Name
+            </label>
+            <input
+              id="admin-name"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              required
+            />
+          </div>
+
+          {/* Dates */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-date">
+              Start date (ISO or yyyy-mm-dd)
+            </label>
+            <input
+              id="admin-date"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.date}
+              onChange={(e) => setDraft({ ...draft, date: e.target.value })}
+              placeholder="2025-11-18T00:00:00.000Z"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-end-date">
+              End date (optional)
+            </label>
+            <input
+              id="admin-end-date"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.endDate ?? ""}
+              onChange={(e) => setDraft({ ...draft, endDate: e.target.value || undefined })}
+              placeholder="2025-11-21T23:59:59.000Z"
+            />
+          </div>
+
+          {/* Location */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-location">
+              Location
+            </label>
+            <input
+              id="admin-location"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.location}
+              onChange={(e) => setDraft({ ...draft, location: e.target.value })}
+              required
+            />
+          </div>
+
+          {/* Price */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-price">
+              Price (USD)
+            </label>
+            <input
+              id="admin-price"
+              type="number"
+              min={0}
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.price}
+              onChange={(e) => setDraft({ ...draft, price: Number(e.target.value) || 0 })}
+              required
+            />
+          </div>
+
+          {/* Categories */}
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium" htmlFor="admin-category">
+              Categories (comma-separated)
+            </label>
+            <input
+              id="admin-category"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.category.join(", ")}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  category: e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+                })
+              }
+              placeholder={knownCategories.join(", ")}
+            />
+          </div>
+
+          {/* Capacity */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-max">
+              Max attendees
+            </label>
+            <input
+              id="admin-max"
+              type="number"
+              min={1}
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.maxAttendees}
+              onChange={(e) =>
+                setDraft({ ...draft, maxAttendees: Math.max(1, Number(e.target.value) || 1) })
+              }
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-current">
+              Current attendees
+            </label>
+            <input
+              id="admin-current"
+              type="number"
+              min={0}
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.currentAttendees}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  currentAttendees: Math.max(0, Number(e.target.value) || 0),
+                })
+              }
+              required
+            />
+          </div>
+
+          {/* Featured + Image URL */}
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-featured">
+              Featured
+            </label>
+            <input
+              id="admin-featured"
+              type="checkbox"
+              className="mt-2"
+              checked={draft.isFeatured}
+              onChange={(e) => setDraft({ ...draft, isFeatured: e.target.checked })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="admin-image">
+              Image URL (optional)
+            </label>
+            <input
+              id="admin-image"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={draft.imageUrl ?? ""}
+              onChange={(e) => setDraft({ ...draft, imageUrl: e.target.value || undefined })}
+              placeholder="/images/placeholder.jpg"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium" htmlFor="admin-description">
+              Description
+            </label>
+            <textarea
+              id="admin-description"
+              className="mt-1 w-full rounded border px-3 py-2"
+              rows={4}
+              value={draft.description}
+              onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 flex gap-2">
+          <button onClick={submitDraft} className="rounded bg-black px-3 py-2 text-white">
+            {mode === "create" ? "Create" : "Save changes"}
+          </button>
+          <button onClick={startCreate} className="rounded border px-3 py-2">
+            Reset form
+          </button>
+        </div>
+      </section>
+    </div>
+    )
+}

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1,0 +1,63 @@
+import { SEED_CONFERENCES } from "@/data/conferences.seed";
+import { Conference } from "@/lib/types"
+
+/**
+ * In-memory store shared by API routes in this build/runtime.
+ * Initialized from seed date. Not persistent across restarts.
+ */
+
+class ConferenceStore {
+    private byId = new Map<string, Conference>();
+
+    constructor(seed: Conference[]){
+        seed.forEach((conf) => this.byId.set(conf.id, {...conf }));
+    }
+
+    //Return a cloned object to avoid external mutation.
+    list(): Conference[]{
+        return Array.from(this.byId.values()).map((c) => ({ ...c }));
+    }
+
+    /**Get a single conference by id, or null if not found */
+    get(id: string): Conference | null {
+        const found = this.byId.get(id);
+        return found ? { ...found } : null;
+    }
+
+    /** Create a new conference; id must be unique */
+    create(input: Conference): Conference {
+        if(this.byId.has(input.id)){
+            throw new Error(`Conference with id "${input.id}" already exists`);
+        }
+        //shallow clone to avoid external mutation
+        const record = { ...input };
+        this.byId.set(record.id, record);
+        return { ...record };
+    }
+
+    /** Update an existing conferency by id */
+    update(id: string, partial: Partial<Conference>): Conference {
+        const existing = this.byId.get(id);
+        if(!existing){
+            throw new Error(`Conference "${id}" not found`);
+        }
+        const updated: Conference = { ...existing, ...partial, id: existing.id };
+        this.byId.set(id, updated);
+        return { ...updated };
+    }
+
+    /** Delete a conference by id (no-op if missing) */
+    delete(id: string): void {
+        this.byId.delete(id);
+    }
+}
+
+//Singleton instace for this server runtime
+export const db = new ConferenceStore(SEED_CONFERENCES);
+
+/** Helper: all known categories (for UI) */
+export function allCategories(): string[]{
+    return Array.from(
+        new Set(db.list().flatMap((c) => c.category))
+    ).sort();
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export interface Conference {
     name: string;
     description: string;
     date: string;
-    endDate: string;
+    endDate?: string;
     location: string;
     price: number;
     category: string [];


### PR DESCRIPTION
- Implemented /api/admin/conferences (+ [id]) GET/POST/PUT/DELETE with input/date validation
- Added AdminClient for list/create/edit/delete flows
- Removed `any`; add Api types and safe JSON parsing
- Fixed endpoint typos; return 204 on DELETE
- Clone on read/write in in-memory store to avoid external mutation
- Home reading from server db instead of SEED_CONFERENCES, new conferences appear immediately
- Pagination fixed
- Category field fixed
