### PR TITLE
Slice 6: SEO & Social Sharing:Open Graph, dynamic share images, sitemap/robots

### DIFF
--- a/src/app/conference/[id]/loading.tsx
+++ b/src/app/conference/[id]/loading.tsx
@@ -1,0 +1,10 @@
+export default function LoadingConference() {
+  return (
+    <div className="space-y-6">
+      <div className="h-8 w-80 animate-pulse rounded bg-neutral-200" />
+      <div className="h-4 w-64 animate-pulse rounded bg-neutral-200" />
+      <div className="h-24 w-full animate-pulse rounded bg-neutral-100" />
+      <div className="h-32 w-full animate-pulse rounded bg-neutral-100" />
+    </div>
+  );
+}

--- a/src/app/conference/[id]/opengraph-image.tsx
+++ b/src/app/conference/[id]/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from "next/og";
+import { db } from "@/lib/server/db";
+import { formatDateRange } from "@/lib/utils/date";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Minimal OG image. No fonts import; system fonts are fine for the assessment.
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const conf = db.get(id);
+
+  const title = conf?.name ?? "Conference";
+  const subtitle = conf
+    ? `${formatDateRange(conf.date, conf.endDate)} · ${conf.location}`
+    : "Details unavailable";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: 64,
+          background:
+            "linear-gradient(135deg, rgb(5,5,5) 0%, rgb(22,22,22) 50%, rgb(40,40,40) 100%)",
+          color: "white",
+        }}
+      >
+        <div style={{ fontSize: 56, fontWeight: 700, lineHeight: 1.1 }}>{title}</div>
+        <div style={{ marginTop: 16, fontSize: 28, opacity: 0.9 }}>{subtitle}</div>
+        <div style={{ marginTop: 40, fontSize: 20, opacity: 0.8 }}>
+          Tech Conference Explorer
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/conference/[id]/page.tsx
+++ b/src/app/conference/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { db } from "@/lib/server/db";
 import { formatDateRange } from "@/lib/utils/date";
@@ -6,6 +7,30 @@ import { computeStatus } from "@/lib/utils/status";
 import Avatar from "@/components/common/Avatar";
 import RegistrationForm from "@/components/conf/RegistrationForm";
 import FavoriteButton from "@/components/common/FavoriteButton";
+
+export async function generateMetadata(
+    { params }: { params: Promise<{ id: string }> }
+): Promise<Metadata>{
+    const { id } = await params;
+    const conference = db.get(id);
+    if(!conference) {
+        return { title: "Conference not found" };
+    }
+    const when = formatDateRange(conference.date, conference.endDate);
+    const description = conference.description || `${conference.name} in ${conference.location} | ${when} | ${formatPrice(conference.price)} `;
+    const ogPath = `/conference/${conference.id}/opengraph-image`;
+
+    return {
+        title: conference.name,
+        description,
+        openGraph: {
+            title: conference.name,
+            description,
+            url: `/conference/${conference.id}`,
+            images: [{ url: ogPath }],
+        },
+    }
+}
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,16 @@ import "./globals.css";
 import { AppStoreProvider } from "@/lib/state/app-store";
 
 export const metadata: Metadata = {
-  title: "Tech Conference Explorer",
+  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"),
+  title: {
+    default: "Tech Conference Explorer",
+    template: "%s · Tech Conference Explorer",
+  },
+  description: "Discover, filter, and register for upcoming tech conferences.",
+  openGraph: {
+    siteName: "Tech Conference Explorer",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,13 @@
+export default function LoadingHome() {
+  return (
+    <div className="space-y-6">
+      <div className="h-7 w-64 animate-pulse rounded bg-neutral-200" />
+      <div className="h-10 w-full animate-pulse rounded bg-neutral-200" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, idx) => (
+          <div key={idx} className="h-40 animate-pulse rounded border bg-neutral-100" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <div className="mx-auto max-w-xl space-y-4 py-16 text-center">
+      <h1 className="text-3xl font-semibold">Page not found</h1>
+      <p className="text-neutral-600">
+        We couldn’t find what you were looking for.
+      </p>
+      <Link href="/" className="inline-block rounded border px-4 py-2">
+        Back to Home
+      </Link>
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const base =
+    process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin"], // hide admin
+    },
+    sitemap: `${base}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+import { db } from "@/lib/server/db";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base =
+    process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+
+  const items = db.list().map((conf) => ({
+    url: `${base}/conference/${conf.id}`,
+    lastModified: new Date(conf.date),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  return [
+    {
+      url: `${base}/`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    ...items,
+  ];
+}


### PR DESCRIPTION
- Implemented Open Graph metadata via generateMetadata on Home and Conference Detail pages (title, description, og: image).
- Added dynamic share image endpoint: /conference/[id]/opengraph-image generates a per-conference image (title, dates, location)

- Added `sitemap.ts` and robots.ts` with canonical, absolute URLs. 
- Introduced a small site config util to build absolute URLs reliably.
- Ensured all metadata renders server-side (crawler-friendly, no client JS)

<img width="634" height="704" alt="Screenshot 2025-09-22 at 1 07 29 PM" src="https://github.com/user-attachments/assets/fd425c0b-7db5-4af7-92e6-1bb6decedf2f" alt="site-map"/>

