### PR TITLE
fix(register): loosen email validation + wire runtime DB + persist registrations

### DIFF
--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -1,183 +1,220 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAppStore } from "@/lib/state/app-store";
-import { SEED_CONFERENCES } from "@/data/conferences.seed";
+import type { Conference } from "@/lib/types";
 import Countdown from "../common/Countdown";
 import ConferenceCard from "../conf/ConferenceCard";
 
-/**
- * Dashboard groups profile editing, favorites, registrations, and a "next-event" countdown
- */
-export default function DashboardClient(){
-    const { state, dispatch } = useAppStore();
+type ApiListResponse = { items: Conference[] };
 
-    //Resolve favorites and registrations to full conference objects
-    const conferenceById = useMemo(() => {
-        const map = new Map(SEED_CONFERENCES.map((c) => [c.id, c]));
-        return (id: string) => map.get(id) ?? null;
-    }, []);
+export default function DashboardClient() {
+  const { state, dispatch } = useAppStore();
 
-    const favoriteConferences = state.favorites
-        .map(conferenceById)
-        .filter((c): c is NonNullable<ReturnType<typeof conferenceById>> => !!c)
-        //sort soonest first
-        .sort(
-            (a, b) =>
-                new Date(a.date).getTime() - new Date(b.date).getTime()
-        );
+  // Load conferences for resolving favorites/registrations
+  const [conferences, setConferences] = useState<Conference[]>([]);
+  const [loadingConfs, setLoadingConfs] = useState(true);
 
-    const registeredConferences = state.registrations.map((r) => conferenceById(r.conferenceId))
-        .filter((c): c is NonNullable<ReturnType<typeof conferenceById>> => !!c)
-        //sort soonest first
-        .sort(
-            (a, b) =>
-                new Date(a.date).getTime() - new Date(b.date).getTime()       
-        );
+  useEffect(() => {
+    let isMounted = true;
+    (async () => {
+      try {
+        // use the public list endpoint with a large pageSize
+        const res = await fetch("/api/conferences?page=1&pageSize=1000", { cache: "no-store" });
+        const data = (await res.json().catch(() => null)) as ApiListResponse | null;
+        if (isMounted && res.ok && data && Array.isArray(data.items)) {
+          setConferences(
+            data.items.slice().sort(
+              (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+            )
+          );
+        }
+      } finally {
+        if (isMounted) setLoadingConfs(false);
+      }
+    })();
+    return () => { isMounted = false; };
+  }, []);
 
-    //Pick "next upcoming" from registrations, first, then favorites, otherwise global earliest
-    const nextUpcoming = useMemo(() => {
-        const upcomingFrom = (list: typeof SEED_CONFERENCES) => list.filter((c) => new Date(c.endDate ?? c.date).getTime() >= Date.now())
-            .sort(
-                (a,b) =>
-                    new Date(a.date).getTime() - new Date(b.date).getTime()
-            )[0] ?? null;
-        
-        return (
-            upcomingFrom(registeredConferences) ||
-            upcomingFrom(favoriteConferences) ||
-            upcomingFrom(SEED_CONFERENCES)
-        );
-    }, [favoriteConferences, registeredConferences]);
+  const conferenceById = useMemo(() => {
+    const map = new Map(conferences.map((c) => [c.id, c]));
+    return (id: string) => map.get(id) ?? null;
+  }, [conferences]);
 
-    //Simple profile edit form
-    const [profileFullName, setProfileFullName] = useState(state.profile.fullName);
-    const [profileEmail, setProfileEmail] = useState(state.profile.email);
-    const [preferredPageSize, setPreferredPageSize] = useState(state.profile.preferredPageSize);
-    const [themeChoice, setThemeChoice] = useState(state.profile.theme);
+  const favoriteConferences = state.favorites
+    .map(conferenceById)
+    .filter((c): c is Conference => !!c)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
-    function saveProfile(){
-        dispatch({
-            type: "set_profile",
-            partial: {
-                fullName: profileEmail.trim(),
-                email: profileEmail.trim(),
-                preferredPageSize: Math.max(1, Math.min(24, Number(preferredPageSize) || 6)),
-                theme: themeChoice,
-            },
-        });
-    }
+  const registeredConferences = state.registrations
+    .map((r) => conferenceById(r.conferenceId))
+    .filter((c): c is Conference => !!c)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
+  const allForNextPick = registeredConferences.length
+    ? registeredConferences
+    : favoriteConferences.length
+    ? favoriteConferences
+    : conferences;
+
+  const nextUpcoming = useMemo(() => {
+    const now = Date.now();
     return (
-        <div className="space-y-8">
-            <header>
-                <h1 className="text-2xl font-semibold">Your Dashboard</h1>
-                {nextUpcoming && (
-                    <p className="mt-1 text-neutral-700">
-                        Next upcoming event starts in: {" "}
-                        <Countdown targetISO={nextUpcoming.date} />
-                        {" "}- {nextUpcoming.name}
-                    </p>
-                )}
-            </header>
-
-            {/* Profile */}
-            <section className="rounded border p-4">
-                <h2 className="mb-3 text-lg font-medium">Profile</h2>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    <div>
-                        <label className="block text-sm font-medium" htmlFor="profile-name">
-                            Full name
-                        </label>
-                        <input
-                            id="profile-name"
-                            className="mt-1 w-full rounded boarder px-3 py-2"
-                            value={profileFullName}
-                            onChange={(e) => setProfileFullName(e.target.value)}
-                            autoComplete="name"
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium" htmlFor="profile-email">
-                            Email
-                        </label>
-                        <input
-                            id="profile-email"
-                            className="mt-1 w-full rounded border px-3 py-2"
-                            type="email"
-                            value={profileEmail}
-                            onChange={(e) => setProfileEmail(e.target.value)}
-                            autoComplete="email"
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium" htmlFor="profile-page-size">
-                            Preferred page size
-                        </label>
-                        <input
-                            id="profile-page-size"
-                            className="mt-1 w-full rounded border px-3 py-2"
-                            type="number"
-                            min={1}
-                            max={24}
-                            value={preferredPageSize}
-                            onChange={(e) => setPreferredPageSize(Number(e.target.value))}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium" htmlFor="profile-theme">
-                            Theme
-                        </label>
-                        <select
-                            id="profile-theme"
-                            className="mt-1 w-full rounded border px-3 py-2"
-                            value={themeChoice}
-                            onChange={(e) => setThemeChoice(e.target.value as typeof state.profile.theme)}
-                            >
-                                <option value="system">System</option>
-                                <option value="light">Light</option>
-                                <option value="dark">Dark</option>
-                            </select>
-                    </div>
-                </div>
-                <div className="mt-3">
-                    <button onClick={saveProfile} className="rounded bg-black px-3 py-2 text-white">
-                        Save Profile
-                    </button>
-                </div>
-            </section>
-
-            {/* Favorites */}
-            <section className="space-y-3">
-                <h2 className="text-lg font-medium">Favorites ({favoriteConferences.length})</h2>
-                {favoriteConferences.length ? (
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                        {favoriteConferences.map((conf) => (
-                            <ConferenceCard key={conf.id} {...conf} />
-                        ))}
-                    </div>
-                ): (
-                    <div className="rounded border p-4 text-neutral-600">
-                        No favorites yet. Mark conferences with &quot;☆ Favorite&quot; to see them here.
-                    </div>
-                )}
-            </section>
-
-            {/* Registrations */}
-            <section className="space-y-3">
-                <h2 className="text-lg font-medium">Registered Conferences ({registeredConferences.length})</h2>
-                {registeredConferences.length ? (
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols2 lg:grid-cols-3">
-                        {registeredConferences.map((conf) => (
-                            <ConferenceCard key={conf.id} {...conf} />
-                        ))}
-                    </div>
-                ): (
-                    <div className="rounded border p-4 text-neutral-600">
-                        You have not registered for any conferences yet.
-                    </div>
-                )}
-            </section>
-        </div>
+      allForNextPick
+        .filter((c) => new Date(c.endDate ?? c.date).getTime() >= now)
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())[0] ?? null
     );
+  }, [allForNextPick]);
+
+  // Profile editor state
+  const [profileFullName, setProfileFullName] = useState(state.profile.fullName);
+  const [profileEmail, setProfileEmail] = useState(state.profile.email);
+  const [preferredPageSize, setPreferredPageSize] = useState(state.profile.preferredPageSize);
+  const [themeChoice, setThemeChoice] = useState(state.profile.theme);
+
+  // Toast
+  const [toast, setToast] = useState<string | null>(null);
+
+  function saveProfile() {
+    dispatch({
+      type: "set_profile",
+      partial: {
+        fullName: profileFullName.trim(),
+        email: profileEmail.trim(),
+        preferredPageSize: Math.max(1, Math.min(24, Number(preferredPageSize) || 6)),
+        theme: themeChoice,
+      },
+    });
+    setToast("Profile saved ✓");
+    setTimeout(() => setToast(null), 2200);
+  }
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-2xl font-semibold text-center">Your Dashboard</h1>
+        {nextUpcoming && (
+          <p className="mt-1 text-neutral-700 text-center">
+            Next upcoming event starts in{" "}
+            <Countdown targetISO={nextUpcoming.date} /> — {nextUpcoming.name}
+          </p>
+        )}
+      </header>
+
+      {/* Profile */}
+      <section className="rounded border p-4">
+        <h2 className="mb-3 text-lg font-medium">Profile</h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium" htmlFor="profile-name">
+              Full name
+            </label>
+            <input
+              id="profile-name"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={profileFullName}
+              onChange={(e) => setProfileFullName(e.target.value)}
+              autoComplete="name"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="profile-email">
+              Email
+            </label>
+            <input
+              id="profile-email"
+              className="mt-1 w-full rounded border px-3 py-2"
+              type="email"
+              value={profileEmail}
+              onChange={(e) => setProfileEmail(e.target.value)}
+              autoComplete="email"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="profile-page-size">
+              Preferred page size
+            </label>
+            <input
+              id="profile-page-size"
+              className="mt-1 w-full rounded border px-3 py-2"
+              type="number"
+              min={1}
+              max={24}
+              value={preferredPageSize}
+              onChange={(e) => setPreferredPageSize(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor="profile-theme">
+              Theme
+            </label>
+            <select
+              id="profile-theme"
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={themeChoice}
+              onChange={(e) => setThemeChoice(e.target.value as typeof state.profile.theme)}
+            >
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+        <div className="mt-3">
+          <button onClick={saveProfile} className="rounded bg-black px-3 py-2 text-white">
+            Save Profile
+          </button>
+        </div>
+      </section>
+
+      {/* Favorites */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Favorites ({favoriteConferences.length})</h2>
+        {loadingConfs ? (
+          <div className="rounded border p-4 text-neutral-600">Loading…</div>
+        ) : favoriteConferences.length ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {favoriteConferences.map((conf) => (
+              <ConferenceCard key={conf.id} {...conf} />
+            ))}
+          </div>
+        ): (
+          <div className="rounded border p-4 text-neutral-600">
+            No favorites yet. Mark conferences with &quot;☆ Favorite&quot; to see them here.
+          </div>
+        )}
+      </section>
+
+      {/* Registrations */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">
+          Registered Conferences ({registeredConferences.length})
+        </h2>
+        {loadingConfs ? (
+          <div className="rounded border p-4 text-neutral-600">Loading…</div>
+        ) : registeredConferences.length ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {registeredConferences.map((conf) => (
+              <ConferenceCard key={conf.id} {...conf} />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded border p-4 text-neutral-600">
+            You have not registered for any conferences yet.
+          </div>
+        )}
+      </section>
+
+      {/* Toast */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded border bg-white px-4 py-2 text-sm shadow"
+        >
+          {toast}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/lib/state/app-store.tsx
+++ b/src/lib/state/app-store.tsx
@@ -100,8 +100,18 @@ export function AppStoreProvider({ children }: { children: React.ReactNode }) {
         try{
             const raw = window.localStorage.getItem(STORAGE_KEY);
             if(raw) {
-                const parsed = JSON.parse(raw) as AppState;
-                dispatch({ type: "load_from_storage", state: parsed });
+                const parsed = JSON.parse(raw) as Partial<AppState>;
+                dispatch({ type: "set_profile", partial: parsed.profile ?? {} });
+                if(Array.isArray(parsed.favorites)) {
+                    parsed.favorites.forEach((id) => 
+                    dispatch({ type: "toggle_favorite", conferenceId: id })
+                );
+            }
+            if(Array.isArray(parsed.registrations)) {
+                parsed.registrations.forEach((entry) => 
+                dispatch({ type: "add_registration", entry: entry as RegistrationEntry })
+            );
+            }
             }
         } catch {
 


### PR DESCRIPTION
Server: relax email regex to /[^@\\s]+@[^@\\s]+\\.[^@\\s]+/i and return consistent { ok, conferenceId } (201)
- API: use runtime db in /api/conferences/[id]/register
- Client: align form validation with server; stop over-disabling submit
- State: properly load/persist registrations in app-store (localStorage)  
- Dashboard: resolve registrations/favorites via /api/conferences list so new regs appear; toast on profile save
- Minor UI polish and typing cleanups