### PR TITLE
feat(conference): center header, unify chips, and add speakers modal

### DIFF
--- a/src/app/conference/[id]/page.tsx
+++ b/src/app/conference/[id]/page.tsx
@@ -4,9 +4,10 @@ import { db } from "@/lib/server/db";
 import { formatDateRange } from "@/lib/utils/date";
 import { formatPrice } from "@/lib/utils/price";
 import { computeStatus } from "@/lib/utils/status";
-import Avatar from "@/components/common/Avatar";
 import RegistrationForm from "@/components/conf/RegistrationForm";
 import FavoriteButton from "@/components/common/FavoriteButton";
+import Chip from "@/components/common/Chip";
+import SpeakersClient from "@/components/conf/SpeakersClient";
 
 export async function generateMetadata(
     { params }: { params: Promise<{ id: string }> }
@@ -48,51 +49,33 @@ export default async function ConferenceDetail({ params }: { params: Promise<{ i
     );
 
     return (
-        <div className="space-y-6">
-            <header className="space-y-2">
-                <h1 className="text-2xl font-semibold">
+        <div className="container mx-auto max-w-5xl space-y-6 px-4 md:px-8">
+            <header className="pt-8 text-center space-y-2">
+                <h1 className="text-4xl font-bold md:text-5xl flex items-center justify-center gap-3">
                     {conference.name}
                     <FavoriteButton conferenceId={conference.id} size="md" />
                 </h1>
-                <div className="text-neutral-600">
+                <div className="text-neutral-500">
                     {when} | {conference.location} | {formatPrice(conference.price)}
                 </div>
-                <div className="flex flex-wrap gap-2">
-                    {conference.category.map((tag) => (
-                        <span key={tag} className="rounded bg-neutral-100 px-2 py-1 text-xs">
-                            {tag}
-                        </span>
-                    ))}
-                </div>
-                <div className="mt-1">
+                {!!conference.category.length && (
+                    <>
+                    <div className="mt-2 flex flex-wrap justify-center gap-2">
+                        {conference.category.map((tag) => (
+                            <Chip key={tag}>{tag}</Chip>
+                        ))}
+                    </div>
                     <StatusBadge status={status} />
-                </div>
+                    </>
+                )}
             </header>
 
-            <section className="prose max-w-none">
+            <section className="flex justify-center prose max-w-none">
                 <p>{conference.description}</p>
             </section>
 
-            {conference.speakers.length > 0 && (
-                <section>
-                    <h2 className="mb-3 text-lg font-medium">
-                        Speakers
-                    </h2>
-                    <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                        {conference.speakers.map((s) => (
-                            <li key={s.id} className="flex items-center gap-3 rounded border p-3">
-                                <Avatar name={s.name} src={s.avatarUrl} size={44} />
-                                <div>
-                                    <div className="font-medium">{s.name}</div>
-                                    <div className="text-sm text-neutral-600">
-                                        {s.title} - {s.company}
-                                    </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                </section>
-            )}
+            {/** Speakers with modal */}
+            <SpeakersClient speakers={conference.speakers} />
 
             <RegistrationForm conferenceId={conference.id} dateISO={conference.endDate ?? conference.date} />
         </div>

--- a/src/components/common/Chip.tsx
+++ b/src/components/common/Chip.tsx
@@ -1,0 +1,21 @@
+type ChipProps = {
+  children: React.ReactNode;
+  title?: string;
+  className?: string;
+};
+
+export default function Chip({ children, title, className }: ChipProps) {
+  return (
+    <span
+      title={title}
+      className={
+        "inline-flex items-center rounded px-2 py-0.5 text-xs " +
+        "bg-neutral-100 text-neutral-800 ring-1 ring-black/5 " +
+        "dark:bg-neutral-200 dark:text-neutral-900 " +
+        (className ?? "")
+      }
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/conf/ConferenceCard.tsx
+++ b/src/components/conf/ConferenceCard.tsx
@@ -5,6 +5,7 @@ import { formatPrice } from "@/lib/utils/price";
 import { computeStatus } from "@/lib/utils/status";
 import type { Conference } from "@/lib/types";
 import FavoriteButton from "../common/FavoriteButton";
+import Chip from "../common/Chip";
 
 function StatusBadge({ status }: { status: "Open" | "Closed" | "Sold Out"}) {
     const styleClass = status === "Open"
@@ -78,16 +79,11 @@ export default function ConferenceCard(props: ConferenceCardProps){
         </p>
 
         <div className="mt-3 flex flex-wrap gap-2">
-            {props.category.map((tag) => (
-            <span
-                key={tag}
-                className="rounded bg-neutral-100 px-2 py-1 text-xs text-neutral-800 group-hover:shadow-sm"
-            >
-                {tag}
-            </span>
-            ))}
+          {props.category.map((tag) => (
+            <Chip key={tag}>{tag}</Chip>
+          ))}
         </div>
-        </div>
+      </div>
     </article>
     );
 }

--- a/src/components/conf/SpeakersClient.tsx
+++ b/src/components/conf/SpeakersClient.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import type { Speaker } from "@/lib/types";
+
+type SpeakersClientProps = {
+  speakers: Speaker[];
+  sectionTitle?: string;
+};
+
+export default function SpeakersClient({
+  speakers,
+  sectionTitle = "Speakers",
+}: SpeakersClientProps) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<Speaker | null>(null);
+  const lastTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  function openModal(speaker: Speaker, trigger: HTMLButtonElement) {
+    setActive(speaker);
+    lastTriggerRef.current = trigger;
+    setOpen(true);
+  }
+
+  function closeModal() {
+    setOpen(false);
+    setActive(null);
+    lastTriggerRef.current?.focus();
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(evt: KeyboardEvent) {
+      if (evt.key === "Escape") closeModal();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  if (!speakers?.length) return null;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-medium">{sectionTitle}</h2>
+
+      <ul className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {speakers.map((sp) => (
+          <li key={sp.id}>
+            <button
+              type="button"
+              onClick={(e) => openModal(sp, e.currentTarget)}
+              className="flex w-full items-center gap-3 rounded border px-3 py-3 text-left transition hover:border-indigo-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            >
+              {sp.avatarUrl ? (
+                <Image
+                  src={sp.avatarUrl}
+                  alt=""
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-10 w-10 rounded-full bg-neutral-200" aria-hidden />
+              )}
+              <div className="min-w-0">
+                <div className="truncate font-medium">{sp.name}</div>
+                <div className="truncate text-sm text-neutral-500">
+                  {sp.title} — {sp.company}
+                </div>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {open && active && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* backdrop */}
+          <div
+            aria-hidden
+            className="absolute inset-0 bg-black/60"
+            onClick={closeModal}
+          />
+          {/* dialog */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${active.name} details`}
+            className="relative z-10 w-full max-w-lg rounded-xl bg-white p-6 shadow-xl dark:bg-neutral-900"
+          >
+            <button
+              onClick={closeModal}
+              aria-label="Close speaker details"
+              className="absolute right-3 top-3 rounded p-1 text-neutral-600 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:text-neutral-300 dark:hover:bg-neutral-800"
+            >
+              ×
+            </button>
+
+            <div className="flex items-center gap-4">
+              {active.avatarUrl ? (
+                <Image
+                  src={active.avatarUrl}
+                  alt=""
+                  width={72}
+                  height={72}
+                  className="h-18 w-18 rounded-full object-cover"
+                />
+              ) : (
+                <div className="h-18 w-18 rounded-full bg-neutral-200" aria-hidden />
+              )}
+              <div>
+                <h3 className="text-xl font-semibold">{active.name}</h3>
+                <p className="text-sm text-neutral-500">
+                  {active.title} — {active.company}
+                </p>
+              </div>
+            </div>
+
+            {active.bio && (
+              <p className="mt-4 text-sm leading-6 text-neutral-700 dark:text-neutral-300">
+                {active.bio}
+              </p>
+            )}
+
+            <div className="mt-6 flex justify-end">
+              <button
+                onClick={closeModal}
+                className="rounded border px-3 py-2 text-sm hover:border-indigo-300 hover:shadow-sm"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
- Centered page header and added consistent container padding
- Replaced inline category pills with shared <Chip> (high-contrast text)
- Swap speakers list for modal-enabled <SpeakersClient> (click card → modal with avatar, title, company, close control)