### PR TITLE
style(admin): center header and add consistent page padding

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,5 +3,9 @@ import AdminClient from "@/components/admin/AdminClient";
 export const dynamic = "force-dynamic";
 
 export default function AdminPage(){
-    return <AdminClient />
+    return (
+    <main className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">    
+        <AdminClient />
+    </main>
+    );
 }

--- a/src/components/admin/AdminClient.tsx
+++ b/src/components/admin/AdminClient.tsx
@@ -166,9 +166,9 @@ export default function AdminClient(){
 
     return (
          <div className="space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Admin — Conferences</h1>
-        <button className="rounded border px-3 py-2" onClick={refreshList}>
+      <header className="flex flex-col items-center justify-between gap-3 sm:flex-row">
+        <h1 className="text-3xl font-semibold text-center sm:text-left">Admin — Conferences</h1>
+        <button className="rounded border px-3 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition" onClick={refreshList}>
           Refresh
         </button>
       </header>


### PR DESCRIPTION
- Wrap /admin in site-wide container (max-w-6xl + responsive horizontal padding)
- Center “Admin - Conferences” heading (responsive: centered on mobile, left on desktop)
- Keep Refresh button aligned and add subtle hover for parity with other pages