### PR TITLE
feat(theme): add client-side theme toggle scaffold wired to profile.s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "TAILWIND_CONFIG=tailwind.config.js next dev --turbopack",
+    "build": "TAILWIND_CONFIG=tailwind.config.js next build --turbopack",
     "start": "next start",
     "lint": "eslint"
+  },
+  "tailwind": {
+  "darkMode": "class",
+  "content": ["./src/**/*.{js,ts,jsx,tsx,mdx}"]
   },
   "dependencies": {
     "next": "15.5.3",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,8 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+:root { color-scheme: light dark; }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+body { 
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji"; 
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AppStoreProvider } from "@/lib/state/app-store";
+import ThemeWatcher from "@/components/common/ThemeWatcher";
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"),
@@ -19,9 +20,14 @@ export default function RootLayout({
   children,
 }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>
-        <AppStoreProvider>{children}</AppStoreProvider>
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-dvh bg-white text-neutral-900 transition-colors dark:bg-neutral-950 dark:text-neutral-100">
+        <AppStoreProvider>
+        <ThemeWatcher />
+        <div className="mx-auto w-full max-w-6xl px-4 md:px-6">
+          {children}
+        </div>
+        </AppStoreProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import ConferenceCard from "@/components/conf/ConferenceCard";
 import SearchPanel from "@/components/conf/SearchPanel";
 import Link from "next/link";
-import { headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 import type { Conference } from "@/lib/types";
 
 type SearchParamMap = Record<string, string | string[] | undefined>;
@@ -58,10 +58,13 @@ export default async function HomePage({
     typeof resolvedParams.page === "string"
       ? Number(resolvedParams.page)
       : 1;
+  const cookieStore = await cookies();
+  const cookiePageSize = Number(cookieStore.get("pref_page_size")?.value ?? "");
+  
   const pageSizeParamRaw =
     typeof resolvedParams.pageSize === "string"
       ? Number(resolvedParams.pageSize)
-      : 6;
+      : (!Number.isNaN(cookiePageSize) && cookiePageSize > 0 ? cookiePageSize : 6);
 
   const pageSize = Math.min(
     24,

--- a/src/components/common/ThemeWatcher.tsx
+++ b/src/components/common/ThemeWatcher.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppStore } from "@/lib/state/app-store";
+
+export default function ThemeWatcher() {
+  const { state } = useAppStore();
+
+  useEffect(() => {
+    const root = document.documentElement;
+   const body = document.body;
+
+   const setMode = (mode: "system" | "light" | "dark") => {
+     const isDark =
+       mode === "dark" ||
+       (mode === "system" &&
+         window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+     // Toggle on BOTH html and body so dark variants always pick up
+     root.classList.toggle("dark", isDark);
+     body.classList.toggle("dark", isDark);
+     // Optional: easy debugging / theming hooks
+     root.setAttribute("data-theme", isDark ? "dark" : "light");
+   };
+   // Apply immediately on mount / change
+   setMode(state.profile.theme);
+
+   // Keep in sync with the OS only when "system"
+   if (state.profile.theme === "system") {
+     const mm = window.matchMedia("(prefers-color-scheme: dark)");
+     const onChange = () => setMode("system");
+     mm.addEventListener("change", onChange);
+     return () => mm.removeEventListener("change", onChange);
+   }}, [state.profile.theme]);
+  return null;
+}

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -14,6 +14,21 @@ export default function DashboardClient() {
   // Load conferences for resolving favorites/registrations
   const [conferences, setConferences] = useState<Conference[]>([]);
   const [loadingConfs, setLoadingConfs] = useState(true);
+  // Profile editor state
+  const [profileFullName, setProfileFullName] = useState(state.profile.fullName);
+  const [profileEmail, setProfileEmail] = useState(state.profile.email);
+  const [preferredPageSize, setPreferredPageSize] = useState(state.profile.preferredPageSize);
+  const [themeChoice, setThemeChoice] = useState(state.profile.theme);
+
+  // Toast
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    setProfileFullName(state.profile.fullName);
+    setProfileEmail(state.profile.email);
+    setPreferredPageSize(state.profile.preferredPageSize);
+    setThemeChoice(state.profile.theme);
+  }, [state.profile]);
 
   useEffect(() => {
     let isMounted = true;
@@ -66,14 +81,6 @@ export default function DashboardClient() {
     );
   }, [allForNextPick]);
 
-  // Profile editor state
-  const [profileFullName, setProfileFullName] = useState(state.profile.fullName);
-  const [profileEmail, setProfileEmail] = useState(state.profile.email);
-  const [preferredPageSize, setPreferredPageSize] = useState(state.profile.preferredPageSize);
-  const [themeChoice, setThemeChoice] = useState(state.profile.theme);
-
-  // Toast
-  const [toast, setToast] = useState<string | null>(null);
 
   function saveProfile() {
     dispatch({
@@ -85,16 +92,22 @@ export default function DashboardClient() {
         theme: themeChoice,
       },
     });
+    //Store preferred page size as a cookie
+    try{
+      const maxAge = 60 * 6 * 24 * 365 //1 year
+      document.cookie = `pref_page_size=${Math.max(1, Math.min(24, Number(preferredPageSize) || 6)
+      )}; Path=/; Max-Age=${maxAge}`;
+    }catch {}
     setToast("Profile saved ✓");
     setTimeout(() => setToast(null), 2200);
   }
 
   return (
-    <div className="space-y-8">
-      <header>
-        <h1 className="text-2xl font-semibold text-center">Your Dashboard</h1>
+    <div className="container mx-auto max-w-5xl px-4 space-y-8">
+      <header className="text-center">
+        <h1 className="text-3xl font-semibold">Your Dashboard</h1>
         {nextUpcoming && (
-          <p className="mt-1 text-neutral-700 text-center">
+          <p className="mt-1 text-neutral-600 dark:text-neutral-300">
             Next upcoming event starts in{" "}
             <Countdown targetISO={nextUpcoming.date} /> — {nextUpcoming.name}
           </p>
@@ -173,7 +186,7 @@ export default function DashboardClient() {
         {loadingConfs ? (
           <div className="rounded border p-4 text-neutral-600">Loading…</div>
         ) : favoriteConferences.length ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-4 grid-cols-[repeat(auto-fit, minmax(280px, 1fr))] mx-auto max-w-6xl w-full">
             {favoriteConferences.map((conf) => (
               <ConferenceCard key={conf.id} {...conf} />
             ))}
@@ -193,7 +206,7 @@ export default function DashboardClient() {
         {loadingConfs ? (
           <div className="rounded border p-4 text-neutral-600">Loading…</div>
         ) : registeredConferences.length ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-4 grid-cols-[repeat(auto-fit, minmax(280px, 1fr))] mx-auto max-w-6xl w-full">
             {registeredConferences.map((conf) => (
               <ConferenceCard key={conf.id} {...conf} />
             ))}
@@ -210,7 +223,8 @@ export default function DashboardClient() {
         <div
           role="status"
           aria-live="polite"
-          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded border bg-white px-4 py-2 text-sm shadow"
+          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded border bg-white px-4 py-2 text-sm shadow
+          bg-white text-neutral-900 border-neutral-200 dark:bg-neutral-900 dark:text-neutral-50 dark:border-neutral-700"
         >
           {toast}
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+
+module.exports = {
+  darkMode: "class",
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+};


### PR DESCRIPTION
Added 'ThemeWatcher' that applies .dark on based on profile.theme (system | light | dark) so user preferences exist and persist.
Wires to AppStore profile; persists in localStorage.
Layout includes ThemeWatcher
Toast text contrast for improved visibility across themes.
Current Limitation

Tailwind is still honoring prefers-color-scheme rather than the .dark class.
TODO:
Confirm Tailwind dark mode is class in the active config used at build/runtime.
Smoke test on /, /dashboard, /conference/[id]
Test Notes

Change theme in Dashboard > Save Profile > Reload the page (profile.theme persists and toggles class correctly) > Visual reflection of inverted theme (Current Limitation)
